### PR TITLE
Return an array containing an empty object

### DIFF
--- a/spec/inverted-index-test.js
+++ b/spec/inverted-index-test.js
@@ -67,6 +67,8 @@ describe("Inverted Index", function() {
         expect(index.getIndex("./jasmine/test.json", "powerful")).toEqual([1]);
         // index.getIndex returns full index object for a given filepath
         expect(index.getIndex("./jasmine/books.json")).toEqual(index.indexObject["books.json"]);
+        // index.getIndex returns an array containing an empty object for a non-existent file 
+        expect(index.getIndex("./jasmine/empty.json")).toEqual([{}]);
         // index.getIndex returns index object for all previously created files
         expect(index.getIndex()).toEqual(index.indexObject);
         done();

--- a/src/inverted-index.js
+++ b/src/inverted-index.js
@@ -131,7 +131,7 @@ function Index() {
     // Get file name from a given filepath.
     key = _this.helperMethods.getFilename(filepath);
     if(!term) {
-      return _this.indexObject[key];
+      return _this.indexObject[key] || [{}];
     }
 
     return _this.indexObject[key][term] || [];


### PR DESCRIPTION
- When getIndex is called on a file path to a none existent file it returns an arr containing an empty method.
- Add test spec for this feature.
